### PR TITLE
Feature/retrotap (Also matrix.c and zip download)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get install -y \
   gcc-avr \
   binutils-avr \
   avr-libc \
-  dfu-programmer
+  dfu-programmer \
+  zip
 WORKDIR /app/qmk-configurator-server
 COPY qmk-configurator-server/package.json /app/qmk-configurator-server
 RUN npm install

--- a/frontend/assets/js/advancedSettingsComponent.js
+++ b/frontend/assets/js/advancedSettingsComponent.js
@@ -25,6 +25,10 @@ Vue.component('advanced-settings-component', {
             <toggle v-model="activeKeyboard.config.permissiveHold"></toggle>
         </div>
         <div class="form-control">
+            <label>Retro Tapping:</label>
+            <toggle v-model="activeKeyboard.config.retroTapping"></toggle>
+        </div>
+        <div class="form-control">
             <label>Locking Support:</label>
             <toggle v-model="activeKeyboard.config.lockingSupportEnabled"></toggle>
         </div>

--- a/frontend/assets/js/keyboard.js
+++ b/frontend/assets/js/keyboard.js
@@ -105,7 +105,8 @@ new Vue({
           keyboardC: response.data.keyboard_c_url,
           keyboardH: response.data.keyboard_h_url,
           keymap: response.data.keymap_url,
-          matrix: response.data.matrix_url
+          matrix: response.data.matrix_url,
+          zip: response.data.zip_url
         };
         context.buildInProgress = false;
       })

--- a/frontend/assets/js/keyboard.js
+++ b/frontend/assets/js/keyboard.js
@@ -104,7 +104,8 @@ new Vue({
           rules: response.data.rules_url,
           keyboardC: response.data.keyboard_c_url,
           keyboardH: response.data.keyboard_h_url,
-          keymap: response.data.keymap_url
+          keymap: response.data.keymap_url,
+          matrix: response.data.matrix_url
         };
         context.buildInProgress = false;
       })

--- a/frontend/assets/js/keyboards/40700/configuration.js
+++ b/frontend/assets/js/keyboards/40700/configuration.js
@@ -31,7 +31,8 @@ fortysevenhundred.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/bananasplit/configuration.js
+++ b/frontend/assets/js/keyboards/bananasplit/configuration.js
@@ -31,7 +31,8 @@ bananasplit.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/caravan2/configuration.js
+++ b/frontend/assets/js/keyboards/caravan2/configuration.js
@@ -32,6 +32,7 @@ caravan.config = {
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
     permissiveHold: true,
+    retroTapping: false,
     rgbDiPin: 'F0',
     rgbLedNum: 20,
     rgblightLimitValue: 255

--- a/frontend/assets/js/keyboards/garbageTruck/configuration.js
+++ b/frontend/assets/js/keyboards/garbageTruck/configuration.js
@@ -31,7 +31,8 @@ garbage_truck.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/jetvan/configuration.js
+++ b/frontend/assets/js/keyboards/jetvan/configuration.js
@@ -33,7 +33,8 @@ jetvan.config = {
     actionFunctionEnabled: true,
     rgbDiPin: 'D0',
     rgbLedNum: 10,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/ketch/configuration.js
+++ b/frontend/assets/js/keyboards/ketch/configuration.js
@@ -35,7 +35,8 @@ ketch.config = {
     actionFunctionEnabled: true,
     rgbDiPin: 'F4',
     rgbLedNum: 10,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/lowwriter/configuration.js
+++ b/frontend/assets/js/keyboards/lowwriter/configuration.js
@@ -31,7 +31,8 @@ lowwriter.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/m3n3van/configuration.js
+++ b/frontend/assets/js/keyboards/m3n3van/configuration.js
@@ -31,7 +31,8 @@ m3n3van.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/mb44/configuration.js
+++ b/frontend/assets/js/keyboards/mb44/configuration.js
@@ -31,7 +31,8 @@ mb44.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/minivan/configuration.js
+++ b/frontend/assets/js/keyboards/minivan/configuration.js
@@ -33,7 +33,8 @@ minivan.config = {
     actionFunctionEnabled: true,
     rgbDiPin: 'D0',
     rgbLedNum: 3,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/neuron/configuration.js
+++ b/frontend/assets/js/keyboards/neuron/configuration.js
@@ -31,7 +31,8 @@ neuron.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/parallelParking/configuration.js
+++ b/frontend/assets/js/keyboards/parallelParking/configuration.js
@@ -32,7 +32,8 @@ parallelParking.config = {
     actionOneShotEnabled: false,
     actionMacroEnabled: false,
     actionFunctionEnabled: false,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/parallelParkingPortScan/configuration.js
+++ b/frontend/assets/js/keyboards/parallelParkingPortScan/configuration.js
@@ -33,7 +33,8 @@ parallelParkingPortScan.config = {
     actionOneShotEnabled: false,
     actionMacroEnabled: false,
     actionFunctionEnabled: false,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/prime_e/configuration.js
+++ b/frontend/assets/js/keyboards/prime_e/configuration.js
@@ -31,7 +31,8 @@ prime_e.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/roadkit/configuration.js
+++ b/frontend/assets/js/keyboards/roadkit/configuration.js
@@ -31,7 +31,8 @@ roadkit.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/skiff/configuration.js
+++ b/frontend/assets/js/keyboards/skiff/configuration.js
@@ -35,7 +35,8 @@ skiff.config = {
     actionFunctionEnabled: true,
     rgbDiPin: 'B0',
     rgbLedNum: 4,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/v4n4g0n/configuration.js
+++ b/frontend/assets/js/keyboards/v4n4g0n/configuration.js
@@ -31,7 +31,8 @@ v4n4g0n.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/assets/js/keyboards/v4n4g0rth0n/configuration.js
+++ b/frontend/assets/js/keyboards/v4n4g0rth0n/configuration.js
@@ -29,7 +29,8 @@ v4n4g0rth0n.config = {
     actionOneShotEnabled: true,
     actionMacroEnabled: true,
     actionFunctionEnabled: true,
-    permissiveHold: true
+    permissiveHold: true,
+    retroTapping: false
 };
 
 // rules

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,6 +48,7 @@
       <raw-output :active-keyboard="activeKeyboard" :keyboards="keyboards" v-on:updateactivekeyboard="updateActiveKeyboard"></raw-output>
 
       <button :disabled="buildInProgress" v-on:click="buildFirmware()" class="btn-primary"><i class="fa fa-download" aria-hidden="true"></i> Build Firmware</button>
+      <button v-if="urls.zip" v-on:click="downloadFile(urls.zip)" class="btn-secondary">zip</button>
       <button v-if="urls.matrix" v-on:click="downloadFile(urls.matrix)" class="btn-secondary">matrix.c</button>
       <button v-if="urls.config" v-on:click="downloadFile(urls.config)" class="btn-secondary">config.h</button>
       <button v-if="urls.rules" v-on:click="downloadFile(urls.rules)" class="btn-secondary">rules.mk</button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,6 +48,7 @@
       <raw-output :active-keyboard="activeKeyboard" :keyboards="keyboards" v-on:updateactivekeyboard="updateActiveKeyboard"></raw-output>
 
       <button :disabled="buildInProgress" v-on:click="buildFirmware()" class="btn-primary"><i class="fa fa-download" aria-hidden="true"></i> Build Firmware</button>
+      <button v-if="urls.matrix" v-on:click="downloadFile(urls.matrix)" class="btn-secondary">matrix.c</button>
       <button v-if="urls.config" v-on:click="downloadFile(urls.config)" class="btn-secondary">config.h</button>
       <button v-if="urls.rules" v-on:click="downloadFile(urls.rules)" class="btn-secondary">rules.mk</button>
       <button v-if="urls.keyboardC" v-on:click="downloadFile(urls.keyboardC)" class="btn-secondary">keyboard.c</button>

--- a/qmk-configurator-server/src/buildConfig.js
+++ b/qmk-configurator-server/src/buildConfig.js
@@ -5,6 +5,7 @@ const populateDefines = (config) => {
   if (config.lockingSupportEnabled) { defines.push('#define LOCKING_SUPPORT_ENABLE'); }
   if (config.lockingResyncEnabled) { defines.push('#define LOCKING_RESYNC_ENABLE'); }
   if (config.permissiveHold) { defines.push('#define PERMISSIVE_HOLD'); }
+  if (config.retroTapping) { defines.push('#define RETRO_TAPPING'); }
   // if (!config.debugEnabled) { defines.push('#define NO_DEBUG'); }
   // if (!config.printEnabled) { defines.push('#define NO_PRINT'); }
   if (!config.actionLayerEnabled) { defines.push('#define NO_ACTION_LAYER'); }

--- a/qmk-configurator-server/src/customMatrix.js
+++ b/qmk-configurator-server/src/customMatrix.js
@@ -163,7 +163,6 @@ static void select_col(uint8_t col) {
 }
 
 static void unselect_col(uint8_t col) { setPinInputHigh(col_pins[col]); }
-MULTIPLEX
 static void unselect_cols(void) {
     for (uint8_t x = 0; x < MATRIX_COLS; x++) {
         setPinInputHigh(col_pins[x]);

--- a/qmk-configurator-server/src/firmware.js
+++ b/qmk-configurator-server/src/firmware.js
@@ -16,7 +16,7 @@ module.exports.setupFirmware = ({config, rules, configKeymap, keymap, indicators
   const now = new Date().toISOString().replace(/[-T:]*/g, '').split('.')[0];
   const fd = `${config.product.replace(/ /, '')}${now}`;
   const firmwareLocation = '/app/qmk_firmware/keyboards';
-  let filesToWrite = 7;
+  let filesToWrite = 8;
 
   const done = () => {
     filesToWrite--;
@@ -35,6 +35,7 @@ module.exports.setupFirmware = ({config, rules, configKeymap, keymap, indicators
     fs.writeFile(`${firmwareLocation}/${fd}/${fd}.c`, buildProductC(fd), done);
     fs.writeFile(`${firmwareLocation}/${fd}/${fd}.h`, buildKeyboardHeader(configKeymap, fd), done);
     fs.writeFile(`${firmwareLocation}/${fd}/keymaps/default/keymap.c`, buildKeymap(keymap, indicators, staticIndicators, rotaryEncoders, fd), done);
+    makeZip(firmwareLocation, fd, done);
   });
 };
 
@@ -47,3 +48,13 @@ module.exports.buildFirmware = (firmwareDirectory, callback) => {
     callback();
   });
 };
+
+const makeZip = (firmwareLocation, firmwareDirectory, callback) => {
+  child_process.exec(`cd ${firmwareLocation}/${firmwareDirectory}; zip -r ../${firmwareDirectory}.zip *; cd ..`,(error, stdout, stderr) => {
+    if (error) {
+      console.log('stdout', stdout);
+      callback(error);
+    }
+    callback();
+  });
+}

--- a/qmk-configurator-server/src/index.js
+++ b/qmk-configurator-server/src/index.js
@@ -41,6 +41,7 @@ app.post('/build', (req, res) => {
       } else {
         res.json({
           'hex_url': `/hex/${fd}_default.hex`,
+          'matrix_url': `/firmware/${fd}/matrix.c`,
           'config_url': `/firmware/${fd}/config.h`,
           'rules_url': `/firmware/${fd}/rules.mk`,
           'keyboard_c_url': `/firmware/${fd}/${fd}.c`,

--- a/qmk-configurator-server/src/index.js
+++ b/qmk-configurator-server/src/index.js
@@ -22,6 +22,10 @@ app.get('/hex/:fileName', (req, res) => {
   res.sendFile(path.join(__dirname, '/../../qmk_firmware', req.params.fileName));
 });
 
+app.get('/zip/:fileName', (req, res) => {
+  res.sendFile(path.join(__dirname, '/../../qmk_firmware/keyboards/', req.params.fileName));
+});
+
 app.get('/firmware/:firmwareDirectory/:fileName', (req, res) => {
   const fmd = req.params.firmwareDirectory;
   res.sendFile(path.join(__dirname, `/../../qmk_firmware/keyboards/${fmd}`, req.params.fileName));
@@ -46,7 +50,8 @@ app.post('/build', (req, res) => {
           'rules_url': `/firmware/${fd}/rules.mk`,
           'keyboard_c_url': `/firmware/${fd}/${fd}.c`,
           'keyboard_h_url': `/firmware/${fd}/${fd}.h`,
-          'keymap_url': `/firmware/${fd}/keymaps/keymap.c`
+          'keymap_url': `/firmware/${fd}/keymaps/keymap.c`,
+          'zip_url': `/zip/${fd}.zip`
         });
       }
     });


### PR DESCRIPTION
1. Added an option for [Retro_Tapping](https://beta.docs.qmk.fm/using-qmk/software-features/tap_hold#retro-tapping):
![image](https://user-images.githubusercontent.com/43552143/122616839-08db3480-d040-11eb-9c4d-5ed28c789b7b.png)

2. Added matrix.c to the list of downloadable files: 
![image](https://user-images.githubusercontent.com/43552143/122616785-f3fea100-d03f-11eb-8f28-60670864a6e6.png)

3. Fixed what I think is a typo in the matrix file, by deleting line 166. I referenced the matrix.c posted on discord in Jan (without rolling back the caravan fix), and I think this is correct. Previously Row2Col firmware wouldn't build, now they do, but I don't have a board to test if the firmware is good.

The problem:
![image](https://user-images.githubusercontent.com/43552143/122617014-5788ce80-d040-11eb-8359-b5a6fc153853.png)

The cause (line 166, which has now been removed):
![image](https://user-images.githubusercontent.com/43552143/122617090-7e470500-d040-11eb-9553-340aced5ac3f.png)

Let me know if you think this is the incorrect fix. If it was intended to not have Row2Col boards build firmware (perhaps something else needs to be fixed first?), I can revert this change if need be.

4. Added option to download a zip of the keyboard folder used to build the firmware. This is done by adding the zip package to the container, and executing on a child process (like how the firmware is built). A new route is added for /zip/ to accommodate this.

The UI change:
![image](https://user-images.githubusercontent.com/43552143/122625578-d1c64c80-d05a-11eb-8c6c-ad201d66a1de.png)

The zip folder contents:
![image](https://user-images.githubusercontent.com/43552143/122625587-e4d91c80-d05a-11eb-8008-fc6a14cc8752.png)

Sorry for putting this all into a single branch / PR ... If you'd like something done differently before approval, please let me know.

-OtherWorlds