### PR TITLE
Allow Both Static Indicators and RGB Indicators on a Single Keyboard

### DIFF
--- a/frontend/assets/css/app.css
+++ b/frontend/assets/css/app.css
@@ -733,6 +733,14 @@ input[type="text"]:focus, input[type="number"]:focus {
   display: inline-block;
 }
 
+.indicatorType {
+  padding: 5px 5px 5px 1%;
+}
+.indicatorType label {
+  width: 20%;
+  display: inline-block;
+}
+
 .col-4 {
   display: inline-block;
   width: 33.33%;

--- a/frontend/assets/js/indicatorTypeSelectorComponent.js
+++ b/frontend/assets/js/indicatorTypeSelectorComponent.js
@@ -1,0 +1,25 @@
+Vue.component('indicator-type-selector-component', {
+  props: ['indicatorTypes'],
+  template: `
+  <div class="zonebox" v-if="indicatorTypes && indicatorTypes.length > 0">
+    <h3 v-on:click="visible = !visible">Indicator Types <span v-if="visible"><i class="fa fa-chevron-down" aria-hidden="true"></i></span><span v-if="!visible"><i class="fa fa-chevron-up" aria-hidden="true"></i></span></h3>
+    <div v-if="visible">
+      <div v-if="visible" class="indicatorType" v-for="indicatorType in indicatorTypes">
+        <label>{{indicatorType.label}}:</label>
+        <select v-model="indicatorType.value" @change="changeIndicatorType">
+          <option v-for="choice in indicatorType.choices" v-bind:value="choice.code">{{ choice.name }}</option>
+        </select>
+      </div>
+    </div>
+  </div>`,
+  data: function() {
+    return {
+      visible: true
+    }
+  },
+  methods: {
+    changeIndicatorType: function() {
+      this.$emit('indicator-type', this.indicatorTypes);
+    },
+  },
+});

--- a/frontend/assets/js/keyboard.js
+++ b/frontend/assets/js/keyboard.js
@@ -85,6 +85,9 @@ new Vue({
     onZoneChange: function(zones) {
       this.layers = this.activeKeyboard.keymap();
     },
+    onIndicatorTypeChange: function() {
+      this.activeKeyboard.updateIndicators();
+    },
     buildFirmware: function() {
     	var context = this;
     	context.buildInProgress = true;

--- a/frontend/assets/js/keyboards/v4n4g0n/configuration.js
+++ b/frontend/assets/js/keyboards/v4n4g0n/configuration.js
@@ -53,23 +53,61 @@ v4n4g0n.rules = {
     rgbLightEnabled: false
 };
 
-v4n4g0n.static_indicators = [
+v4n4g0n.indicator_types = [
   {
-    pin: 'B6',
-    type: 'power',
-    action: 'power'
-  },
-  {
-    pin: 'B5',
-    type: 'layer',
-    action: 'L3'
-  },
-  {
-    pin: 'B4',
-    type: 'layer',
-    action: 'L3'
+    label: 'Indicator Type',
+    value: 0,
+    choices: [
+      {
+        code: 0,
+        name: 'Static Indicators',
+        static_indicators: [
+          {
+            pin: 'B6',
+            type: 'power',
+            action: 'power'
+          },
+          {
+            pin: 'B5',
+            type: 'layer',
+            action: 'L3'
+          },
+          {
+            pin: 'B4',
+            type: 'layer',
+            action: 'L3'
+          }
+        ],
+        indicators: [],
+        rgbDiPin: undefined,
+        rgbLedNum: undefined,
+        rgbLightEnabled: undefined
+      },
+      {
+        code: 1,
+        name: 'RGB Indicators',
+        indicators: [
+          [
+            {red: 200, green: 23, blue: 23, action: 'power', type: 'power'}
+          ],
+          [
+            {red: 200, green: 23, blue: 23, action: 'power', type: 'power'}
+          ],
+          [
+            {red: 200, green: 23, blue: 23, action: 'power', type: 'power'}
+          ],
+        ],
+        static_indicators: [],
+        rgbDiPin: 'D0',
+        rgbLedNum: 3,
+        rgbLightEnabled: true
+      }
+    ]
   }
 ];
+
+v4n4g0n.indicators = v4n4g0n.indicator_types[0].choices[0].indicators;
+v4n4g0n.static_indicators = v4n4g0n.indicator_types[0].choices[0].static_indicators;
 
 // keymap
 v4n4g0n.configKeymap = {};
@@ -2143,6 +2181,17 @@ v4n4g0n.keySections = [
         ]
     }
 ];
+
+v4n4g0n.updateIndicators = function() {
+  var indicatorTypes = v4n4g0n.indicator_types;
+  var selected = indicatorTypes[0].choices[indicatorTypes[0].value];
+
+  v4n4g0n.indicators = selected.indicators;
+  v4n4g0n.static_indicators = selected.static_indicators;
+  v4n4g0n.config.rgbDiPin = selected.rgbDiPin;
+  v4n4g0n.config.rgbLedNum = selected.rgbLedNum;
+  v4n4g0n.rules.rgbLightEnabled = selected.rgbLightEnabled;
+}
 
 v4n4g0n.keymap = function() {
     var keymap = [];

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,7 @@
       <keyboard-selector-component v-model="activeKeyboard" :keyboards="keyboards"></keyboard-selector-component>
       <advanced-settings-component :active-keyboard="activeKeyboard"></advanced-settings-component>
       <zone-selector-component v-on:zone="onZoneChange" :zones="zones"></zone-selector-component>
+      <indicator-type-selector-component v-on:indicator-type="onIndicatorTypeChange" :indicator-types="activeKeyboard.indicator_types"></indicator-type-selector-component>
       <indicators :indicators="activeKeyboard.indicators"></indicators>
       <static-indicators :indicators="activeKeyboard.static_indicators"></static-indicators>
       <rotary-encoders :encoders="activeKeyboard.rotary_encoders"></rotary-encoders>
@@ -83,6 +84,7 @@
     <script src="assets/js/keyboardSelectorComponent.js"></script>
     <script src="assets/js/savedLayoutSelectorComponent.js"></script>
     <script src="assets/js/colorPickerComponent.js"></script>
+    <script src="assets/js/indicatorTypeSelectorComponent.js"></script>
     <script src="assets/js/indicatorsComponent.js"></script>
     <script src="assets/js/staticIndicatorsComponent.js"></script>
     <script src="assets/js/encodersComponent.js"></script>


### PR DESCRIPTION
This pull sets up the scaffolding for allowing both static indicators and RGB indicators on a single keyboard as well as implementing the switch on keyboards/v4n4g0n.

The type selector is modeled after the zone selector and allows for the ability to switch between combinations of indicator types as defined by the keyboard, e.g. all static, all rgb, some mixture.

v4n4g0n is currently configured for static indicators on initial page load with the ability to switch to RGB, but that can be swapped easily enough if desired.

<img width="762" alt="Screen Shot 2021-11-01 at 6 38 34 PM" src="https://user-images.githubusercontent.com/419620/139739105-2455b9fd-6927-4fa6-a7c0-c61b4ba77949.png">

@evangs let me know what you think